### PR TITLE
Ignore Escape key

### DIFF
--- a/src/FsReadLine/ReadLine.fs
+++ b/src/FsReadLine/ReadLine.fs
@@ -212,6 +212,7 @@ let keyHandle ctxt (info: ConsoleKeyInfo) =
   | ConsoleKey.P when isCtrlPushed -> prevHistory ctxt
   | ConsoleKey.N when isCtrlPushed -> nextHistory ctxt
   | ConsoleKey.K when isCtrlPushed -> removeFromCursorToEnd ctxt
+  | ConsoleKey.Escape -> ctxt
   | _ -> info.KeyChar |> writeChar ctxt
 
 let private updateHistory ctxt cmdline =


### PR DESCRIPTION

Modify Escape Key to Ignore

```
diff --git a/src/FsReadLine/ReadLine.fs b/src/FsReadLine/ReadLine.fs
index 5e4be8f..d0a95c2 100644
--- a/src/FsReadLine/ReadLine.fs
+++ b/src/FsReadLine/ReadLine.fs
@@ -212,6 +212,7 @@ let keyHandle ctxt (info: ConsoleKeyInfo) =
   | ConsoleKey.P when isCtrlPushed -> prevHistory ctxt
   | ConsoleKey.N when isCtrlPushed -> nextHistory ctxt
   | ConsoleKey.K when isCtrlPushed -> removeFromCursorToEnd ctxt
+  | ConsoleKey.Escape -> ctxt
   | _ -> info.KeyChar |> writeChar ctxt

 let private updateHistory ctxt cmdline =
```